### PR TITLE
Never use exception as the base class of an exception

### DIFF
--- a/lib/geoutm/geo_utm_exception.rb
+++ b/lib/geoutm/geo_utm_exception.rb
@@ -1,4 +1,4 @@
 module GeoUtm
-	class GeoUtmException < Exception
+	class GeoUtmException < StandardError
 	end
 end


### PR DESCRIPTION
See http://blog.nicksieger.com/articles/2006/09/06/rubys-exception-hierarchy/ for more details about the exception class hierarchy in ruby
