### PR TITLE
use the zone to determine the hemisphere

### DIFF
--- a/lib/geoutm/utm.rb
+++ b/lib/geoutm/utm.rb
@@ -50,7 +50,7 @@ module GeoUtm
       utm_easting = k0*n*(a+(1-t+c)*a*a*a/6 + (5-18*t+t*t+72*c-58*eccentprime)*a*a*a*a*a/120) + 500000.0
       utm_northing = k0 * ( m + n*Math::tan(lat_rad) * ( a*a/2+(5-t+9*c+4*c*c)*a*a*a*a/24 + 
                                    (61-58*t+t*t+600*c-330*eccentprime) * a*a*a*a*a*a/720))
-      utm_northing += 10000000.0 if latlon.lat < 0
+      utm_northing += 10000000.0 if !UTMZones::northern_hemisphere?(zone)
       UTM.new zone, utm_easting, utm_northing, ellipsoid
     end
 

--- a/spec/geoutm_spec.rb
+++ b/spec/geoutm_spec.rb
@@ -25,6 +25,13 @@ module GeoUtm
         utm.zone.should == sample[:zone]
       end
     end
+    
+    it "should use the zone to determine if within the northern or southern emisphere" do
+      latlon = LatLon.new(-0.001, -51.081063)
+      utm = latlon.to_utm zone: '22N'
+      utm.n.should be_within(1).of(-111)
+      utm.zone.should == "22N"
+    end
 
     it "should convert from UTM to lat/lon" do
       @testdata.each do |sample|


### PR DESCRIPTION
to_utm currently uses the sign of the latitude to determine the hemisphere, which is inconsistent with the ability to give a full zone.

My personal use case is to force the zone so that I don't get jumps when passing through a special UTM line (either east/west or north/south) at the cost of precision in the mapping.